### PR TITLE
Improve wksocket robustness and security

### DIFF
--- a/wksocket/Cargo.toml
+++ b/wksocket/Cargo.toml
@@ -13,6 +13,7 @@ log = { version = "0.4", default-features = false }
 time = "0.3"
 rand = "0.9"
 md-5 = "0.10"
+subtle = "2.5"
 
 [target.'cfg(any(target_arch = "xtensa", target_arch = "riscv32"))'.dependencies]
 esp-idf-sys = { version = "0.36", features = ["binstart"] }


### PR DESCRIPTION
## Summary
- `panic!` を `Result` に変更し、graceful error handling を実現
- `unwrap()` を適切なエラーハンドリングに置換
- `UDPOutput::write` でエラーを抑制せず伝播するよう修正
- 認証チャレンジで `subtle` crateによる定数時間比較を導入

## 変更内容

### wkmessage.rs
- `encode()` が `Result` を返すよう変更
- `session.close()` の `unwrap()` を `let _ =` に変更
- `tx.send()` の `unwrap()` を `map_err` に変更

### wksession.rs  
- `KcpSocket::new()` / `WkSession::new()` が `Result` を返すよう変更
- `Mutex::lock().unwrap()` を `map_err` / `let-else` パターンに変更
- `UDPOutput::write` でエラーをログ出力し、KCPに伝播
- 認証比較を `subtle::ConstantTimeEq` で実装

## Test plan
- [ ] `cargo check -p wksocket` がパス
- [ ] `cargo check -p wifikey-server` がパス
- [ ] `cargo check -p mqttstunclient` がパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)